### PR TITLE
feat(login): add login page UI + validation (mock auth)

### DIFF
--- a/src/pages/login.html
+++ b/src/pages/login.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Serenità — Login</title>
+
+  <!-- design tokens (variáveis) -->
+  <link rel="stylesheet" href="../styles/variables.css">
+  <link rel="stylesheet" href="../styles/base.css">
+  <link rel="stylesheet" href="../styles/components.css">
+  <!-- page specific -->
+  <link rel="stylesheet" href="../styles/login.css">
+</head>
+<body>
+  <main class="auth-page">
+    <section class="auth-card" role="main" aria-labelledby="auth-title">
+      <div class="auth-top">
+        <!-- Logo: use your SVG in public/assets/images/logo-serenita.svg -->
+        <div class="logo-round" aria-hidden="true">
+          <img src="/public/assets/images/logo-serenita.svg" alt="Serenità" onerror="this.style.display='none'">
+          <span class="logo-fallback" aria-hidden="true">S</span>
+        </div>
+        <h1 id="auth-title" class="auth-title">Serenità</h1>
+        <p class="auth-sub">Seu companheiro diário para acompanhamento de saúde mental e autocuidado</p>
+      </div>
+
+      <form id="loginForm" class="auth-form" novalidate>
+        <label for="email" class="form-label">E-mail</label>
+        <div class="input-wrap">
+          <span class="input-icon" aria-hidden="true">✉️</span>
+          <input id="email" name="email" type="email" inputmode="email"
+                 placeholder="seu@email.com"
+                 autocomplete="email"
+                 required
+                 class="input-field"/>
+        </div>
+        <div id="emailError" class="field-error" aria-live="polite"></div>
+
+        <label for="password" class="form-label">Senha <a href="#" class="link-muted small float-right" id="forgotLink">Esqueceu a senha?</a></label>
+        <div class="input-wrap">
+          <span class="input-icon" aria-hidden="true">🔒</span>
+          <input id="password" name="password" type="password"
+                 placeholder="••••••••"
+                 autocomplete="current-password"
+                 required
+                 minlength="6"
+                 class="input-field"/>
+          <button type="button" id="togglePwd" class="pwd-toggle" aria-label="Mostrar senha">👁️</button>
+        </div>
+        <div id="pwdError" class="field-error" aria-live="polite"></div>
+
+        <button id="submitBtn" type="submit" class="btn btn-primary full" disabled>Entrar</button>
+
+        <div class="separator"><span>Ou continue com</span></div>
+
+        <!-- Removed Google option per request. Keeping a neutral placeholder area -->
+        <div class="social-placeholder">
+          <!-- empty by design -->
+        </div>
+
+        <p class="muted small center">Não tem uma conta? <a href="../pages/signup.html" class="link-accent">Cadastre-se</a></p>
+
+        <div id="feedback" class="feedback" aria-live="polite"></div>
+      </form>
+    </section>
+  </main>
+
+  <script src="../pages/login.js"></script>
+</body>
+</html>

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,0 +1,86 @@
+// login.js - simple client validation + mock auth
+
+(function(){
+  const form = document.getElementById('loginForm');
+  const emailEl = document.getElementById('email');
+  const pwdEl = document.getElementById('password');
+  const toggleBtn = document.getElementById('togglePwd');
+  const submitBtn = document.getElementById('submitBtn');
+  const emailError = document.getElementById('emailError');
+  const pwdError = document.getElementById('pwdError');
+  const feedback = document.getElementById('feedback');
+
+  // show/hide password
+  toggleBtn.addEventListener('click', () => {
+    const type = pwdEl.type === 'password' ? 'text' : 'password';
+    pwdEl.type = type;
+    toggleBtn.setAttribute('aria-label', type === 'text' ? 'Ocultar senha' : 'Mostrar senha');
+  });
+
+  // simple validators
+  function isValidEmail(v){
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+  }
+  function isValidPwd(v){ return v && v.length >= 6; }
+
+  function validate(){
+    let ok = true;
+    emailError.textContent = '';
+    pwdError.textContent = '';
+    feedback.textContent = '';
+
+    if(!isValidEmail(emailEl.value.trim())){
+      emailError.textContent = 'Informe um e-mail válido';
+      ok = false;
+    }
+    if(!isValidPwd(pwdEl.value)){
+      pwdError.textContent = 'Senha deve ter pelo menos 6 caracteres';
+      ok = false;
+    }
+    submitBtn.disabled = !ok;
+    return ok;
+  }
+
+  // validate on input
+  emailEl.addEventListener('input', validate);
+  pwdEl.addEventListener('input', validate);
+
+  // mock auth on submit
+  form.addEventListener('submit', function(e){
+    e.preventDefault();
+    if(!validate()) return;
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Entrando...';
+    feedback.textContent = '';
+
+    const payload = { email: emailEl.value.trim(), password: pwdEl.value };
+
+    // mock server latency
+    setTimeout(() => {
+      // mock success when email contains "demo" or any valid non-empty creds
+      if(payload.email.includes('demo') || payload.email.length>5){
+        feedback.style.color = 'var(--teal-300)';
+        feedback.textContent = 'Login realizado com sucesso. Redirecionando...';
+        // redirect (mock)
+        setTimeout(()=>{ window.location.href = "../index.html"; }, 900);
+      } else {
+        feedback.style.color = '#ffb4c0';
+        feedback.textContent = 'E-mail ou senha inválidos.';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Entrar';
+      }
+    }, 700);
+  });
+
+  // initial validation attempt
+  validate();
+
+  // forgot password link placeholder behavior
+  const forgotLink = document.getElementById('forgotLink');
+  forgotLink.addEventListener('click', function(e){
+    e.preventDefault();
+    alert('Funcionalidade de recuperação de senha será implementada em breve.');
+  });
+
+})();

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -1,0 +1,88 @@
+/* login.css - specific styles for login page (uses variables.css) */
+
+.auth-page{
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:28px;
+  background: var(--bg-primary);
+}
+
+/* card */
+.auth-card{
+  width:100%;
+  max-width:420px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  border: 1px solid var(--border-primary);
+  border-radius: 14px;
+  padding:28px;
+  box-shadow: 0 10px 30px rgba(2,6,23,0.6);
+  color: var(--text-primary);
+}
+
+/* top / logo */
+.auth-top{ text-align:center; margin-bottom:14px }
+.logo-round{
+  width:56px;height:56px;border-radius:50%;margin:0 auto 12px;
+  background:rgba(255,255,255,0.02); display:flex;align-items:center;justify-content:center;
+  border:1px solid rgba(255,255,255,0.03);
+}
+.logo-round img{ width:44px; height:44px; display:block; }
+.logo-fallback{ color:var(--teal-300); font-weight:700; font-size:20px; }
+
+/* title */
+.auth-title{ font-size:24px; margin:6px 0 6px; font-weight:700; color:var(--text-primary) }
+.auth-sub{ color:var(--text-muted); font-size:14px; margin:0 0 18px }
+
+/* form */
+.auth-form{ display:block }
+.form-label{ display:block; color:var(--text-tertiary); font-size:13px; margin:10px 0 6px }
+.input-wrap{ position:relative; display:flex; align-items:center; gap:10px; margin-bottom:6px }
+.input-icon{ width:36px; display:inline-flex; align-items:center; justify-content:center; color:var(--text-muted) }
+.input-field{
+  flex:1; background:transparent; border:1px solid var(--border-secondary); padding:12px 14px; border-radius:10px;
+  color:var(--text-primary); font-size:14px;
+}
+.input-field::placeholder{ color:var(--text-tertiary) }
+
+/* password toggle */
+.pwd-toggle{ position:absolute; right:8px; background:transparent; border:0; color:var(--text-muted); cursor:pointer; padding:6px; border-radius:6px }
+.pwd-toggle:focus{ outline:2px solid rgba(20,184,166,0.12) }
+
+/* errors and feedback */
+.field-error{ color:#ffb4c0; font-size:13px; min-height:18px; margin-bottom:6px }
+.feedback{ margin-top:12px; font-size:14px; min-height:20px }
+
+/* primary button */
+.btn.full{ width:100%; display:inline-block; text-align:center }
+.btn-primary.full{
+  background: linear-gradient(90deg, var(--teal-600), var(--teal-300));
+  color:#001;
+  padding:12px 14px;
+  font-weight:700;
+  border-radius:10px;
+  border:none;
+  box-shadow: 0 8px 18px rgba(13,148,136,0.12);
+}
+.btn-primary.full[disabled]{ opacity:.6; cursor:not-allowed; transform:none; box-shadow:none }
+
+/* separator */
+.separator{ display:flex; align-items:center; gap:12px; margin:18px 0; color:var(--text-tertiary); font-size:13px }
+.separator::before, .separator::after{ content:""; flex:1; height:1px; background:rgba(255,255,255,0.03); border-radius:2px }
+
+/* links */
+.link-muted{ color:var(--text-muted); text-decoration:none }
+.link-accent{ color:var(--teal-300); text-decoration:none; font-weight:600 }
+.link-accent:hover{ color:var(--teal-500) }
+
+/* small text */
+.small{ font-size:13px }
+.center{text-align:center}
+.muted{ color:var(--text-muted) }
+
+/* responsive */
+@media (max-width:480px){
+  .auth-card{ padding:20px; border-radius:12px }
+  .auth-title{ font-size:22px }
+}


### PR DESCRIPTION
- Implementação da página de login seguindo o protótipo feito no v0
- Client-side validation for email and password (min 6 chars).
- Show/hide password toggle.
- Mock authentication: accepts emails containing "demo" (redirects to index.html).
- Uses design tokens from variables.css and components.css.

How to test:
1. Open src/pages/login.html with Live Server.
2. Try valid email (e.g., user@demo.com) and password >=6 chars → should show success and redirect (mock).
3. Try invalid email / short password → should show inline errors.

- [x] UI conforme protótipo (desktop & mobile)
- [x] Validação de e-mail e senha implementada
- [x] Mensagens de erro exibidas corretamente
- [x] Show/hide password funcionando
- [x] Acessibilidade básica (labels, aria-live)
- [x] Testado localmente com Live Server