### PR TITLE
feat(signup): add signup page UI + validation (mock auth)

### DIFF
--- a/src/pages/signup.html
+++ b/src/pages/signup.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Serenità — Criar conta</title>
+
+  <!-- design tokens (variáveis) -->
+  <link rel="stylesheet" href="../styles/variables.css">
+  <link rel="stylesheet" href="../styles/base.css">
+  <link rel="stylesheet" href="../styles/components.css">
+  <!-- page specific -->
+  <link rel="stylesheet" href="../styles/signup.css">
+</head>
+<body>
+  <main class="auth-page">
+    <section class="auth-card" role="main" aria-labelledby="auth-title">
+      <div class="auth-top">
+        <!-- Logo: use same asset as login -->
+        <div class="logo-round" aria-hidden="true">
+          <img src="/public/assets/images/logo-serenita.svg" alt="Serenità" onerror="this.style.display='none'">
+          <span class="logo-fallback" aria-hidden="true">S</span>
+        </div>
+
+        <h1 id="auth-title" class="auth-title">Serenità</h1>
+        <p class="auth-sub">Bem-vindo(a) ao Serenità. Para começar sua jornada de serenidade, preencha seus dados. É rápido e fácil.</p>
+      </div>
+
+      <form id="signupForm" class="auth-form" novalidate>
+        <div class="row-2" style="gap:12px; display:flex; margin-bottom:6px;">
+          <div style="flex:1">
+            <label for="firstName" class="form-label">Nome</label>
+            <div class="input-wrap">
+              <input id="firstName" name="firstName" type="text" placeholder="Seu nome" autocomplete="given-name" required class="input-field"/>
+            </div>
+            <div id="firstNameError" class="field-error" aria-live="polite"></div>
+          </div>
+
+          <div style="flex:1">
+            <label for="lastName" class="form-label">Sobrenome</label>
+            <div class="input-wrap">
+              <input id="lastName" name="lastName" type="text" placeholder="Seu sobrenome" autocomplete="family-name" required class="input-field"/>
+            </div>
+            <div id="lastNameError" class="field-error" aria-live="polite"></div>
+          </div>
+        </div>
+
+        <label for="email" class="form-label">E-mail</label>
+        <div class="input-wrap">
+          <span class="input-icon" aria-hidden="true">✉️</span>
+          <input id="email" name="email" type="email" inputmode="email"
+                 placeholder="seu@email.com"
+                 autocomplete="email"
+                 required
+                 class="input-field"/>
+        </div>
+        <div id="emailError" class="field-error" aria-live="polite"></div>
+
+        <label for="password" class="form-label">Senha</label>
+        <div class="input-wrap" style="position:relative;">
+          <span class="input-icon" aria-hidden="true">🔒</span>
+          <input id="password" name="password" type="password"
+                 placeholder="••••••••"
+                 autocomplete="new-password"
+                 required
+                 minlength="6"
+                 class="input-field"/>
+          <button type="button" id="togglePwd" class="pwd-toggle" aria-label="Mostrar senha">👁️</button>
+        </div>
+        <div id="pwdError" class="field-error" aria-live="polite"></div>
+
+        <label for="confirmPassword" class="form-label">Confirmar senha</label>
+        <div class="input-wrap" style="position:relative;">
+          <span class="input-icon" aria-hidden="true">🔒</span>
+          <input id="confirmPassword" name="confirmPassword" type="password"
+                 placeholder="Repita a senha"
+                 autocomplete="new-password"
+                 required
+                 minlength="6"
+                 class="input-field"/>
+          <button type="button" id="togglePwdConfirm" class="pwd-toggle" aria-label="Mostrar senha">👁️</button>
+        </div>
+        <div id="confirmPwdError" class="field-error" aria-live="polite"></div>
+
+        <button id="submitBtn" type="submit" class="btn btn-primary full" disabled>Criar conta</button>
+
+        <!-- intentionally removed Google/terms per spec; keep a neutral spacer similar to login -->
+        <div style="height:12px"></div>
+
+        <p class="muted small center">Já tem uma conta? <a href="../pages/login.html" class="link-accent">Entrar</a></p>
+
+        <div id="feedback" class="feedback" aria-live="polite"></div>
+      </form>
+    </section>
+  </main>
+
+  <script src="../pages/signup.js"></script>
+</body>
+</html>

--- a/src/pages/signup.js
+++ b/src/pages/signup.js
@@ -1,0 +1,116 @@
+// signup.js - client validation + mock signup (consistent with login.js)
+
+(function(){
+  const form = document.getElementById('signupForm');
+  const firstNameEl = document.getElementById('firstName');
+  const lastNameEl = document.getElementById('lastName');
+  const emailEl = document.getElementById('email');
+  const pwdEl = document.getElementById('password');
+  const confirmPwdEl = document.getElementById('confirmPassword');
+
+  const toggleBtn = document.getElementById('togglePwd');
+  const toggleBtnConfirm = document.getElementById('togglePwdConfirm');
+  const submitBtn = document.getElementById('submitBtn');
+
+  const firstNameError = document.getElementById('firstNameError');
+  const lastNameError = document.getElementById('lastNameError');
+  const emailError = document.getElementById('emailError');
+  const pwdError = document.getElementById('pwdError');
+  const confirmPwdError = document.getElementById('confirmPwdError');
+  const feedback = document.getElementById('feedback');
+
+  // toggle password visibility
+  function toggleVisibility(inputEl, btnEl) {
+    if (!inputEl || !btnEl) return;
+    btnEl.addEventListener('click', () => {
+      const type = inputEl.type === 'password' ? 'text' : 'password';
+      inputEl.type = type;
+      btnEl.setAttribute('aria-label', type === 'text' ? 'Ocultar senha' : 'Mostrar senha');
+    });
+  }
+  toggleVisibility(pwdEl, toggleBtn);
+  toggleVisibility(confirmPwdEl, toggleBtnConfirm);
+
+  // validators
+  function isValidEmail(v){
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+  }
+  function isValidPwd(v){ return v && v.length >= 6; }
+  function isNonEmpty(v){ return v && v.trim().length > 0; }
+
+  function validate(){
+    let ok = true;
+    // clear
+    firstNameError.textContent = '';
+    lastNameError.textContent = '';
+    emailError.textContent = '';
+    pwdError.textContent = '';
+    confirmPwdError.textContent = '';
+    feedback.textContent = '';
+
+    if(!isNonEmpty(firstNameEl.value)){
+      firstNameError.textContent = 'Informe seu nome';
+      ok = false;
+    }
+    if(!isNonEmpty(lastNameEl.value)){
+      lastNameError.textContent = 'Informe seu sobrenome';
+      ok = false;
+    }
+    if(!isValidEmail(emailEl.value.trim())){
+      emailError.textContent = 'Informe um e-mail válido';
+      ok = false;
+    }
+    if(!isValidPwd(pwdEl.value)){
+      pwdError.textContent = 'Senha deve ter pelo menos 6 caracteres';
+      ok = false;
+    }
+    if(pwdEl.value !== confirmPwdEl.value){
+      confirmPwdError.textContent = 'Senhas não coincidem';
+      ok = false;
+    }
+
+    submitBtn.disabled = !ok;
+    return ok;
+  }
+
+  // validate on input
+  [firstNameEl, lastNameEl, emailEl, pwdEl, confirmPwdEl].forEach(el => {
+    if(!el) return;
+    el.addEventListener('input', validate);
+  });
+
+  // form submit (mock)
+  if (form) {
+    form.addEventListener('submit', function(e){
+      e.preventDefault();
+      if(!validate()) return;
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Registrando...';
+      feedback.textContent = '';
+
+      const payload = {
+        firstName: firstNameEl.value.trim(),
+        lastName: lastNameEl.value.trim(),
+        email: emailEl.value.trim(),
+        password: pwdEl.value
+      };
+
+      // fallback behavior (mock server)
+      setTimeout(() => {
+        // success criteria: simple acceptance for testing
+        feedback.style.color = 'var(--teal-300)';
+        feedback.textContent = 'Cadastro realizado com sucesso. Você será redirecionado para entrar.';
+        console.log('Signup payload (modo teste):', payload);
+
+        setTimeout(() => {
+          window.location.href = "../pages/login.html"; // volta para login (ajuste conforme estrutura)
+        }, 900);
+      }, 700);
+    });
+  }
+
+  // initial validation attempt
+  validate();
+
+})();

--- a/src/styles/signup.css
+++ b/src/styles/signup.css
@@ -1,0 +1,92 @@
+/* signup.css - specific styles for signup page (consistent with login.css) */
+
+/* Reutiliza as variáveis definidas em variables.css */
+
+/* página / container */
+.auth-page{
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:28px;
+  background: var(--bg-primary);
+}
+
+/* card */
+.auth-card{
+  width:100%;
+  max-width:500px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  border: 1px solid var(--border-primary);
+  border-radius: 14px;
+  padding:28px;
+  box-shadow: 0 10px 30px rgba(2,6,23,0.6);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+/* top / logo */
+.auth-top{ text-align:center; margin-bottom:14px }
+.logo-round{
+  width:56px;height:56px;border-radius:50%;margin:0 auto 12px;
+  background:rgba(255,255,255,0.02); display:flex;align-items:center;justify-content:center;
+  border:1px solid rgba(255,255,255,0.03);
+}
+.logo-round img{ width:44px; height:44px; display:block; }
+.logo-fallback{ color:var(--teal-300); font-weight:700; font-size:20px; }
+
+/* title and subtitle */
+.auth-title{ font-size:24px; margin:6px 0 6px; font-weight:700; color:var(--text-primary) }
+.auth-sub{ color:var(--text-muted); font-size:14px; margin:0 0 18px }
+
+/* layout helpers */
+.row-2 { display:flex; gap:12px; }
+
+/* form */
+.auth-form{ display:block }
+.form-label{ display:block; color:var(--text-tertiary); font-size:13px; margin:10px 0 6px }
+.input-wrap{ position:relative; display:flex; align-items:center; gap:10px; margin-bottom:6px }
+.input-icon{ width:36px; display:inline-flex; align-items:center; justify-content:center; color:var(--text-muted) }
+.input-field{
+  flex:1; background:transparent; border:1px solid var(--border-secondary); padding:12px 14px; border-radius:10px;
+  color:var(--text-primary); font-size:14px;
+}
+.input-field::placeholder{ color:var(--text-tertiary) }
+
+/* password toggle */
+.pwd-toggle{ position:absolute; right:8px; background:transparent; border:0; color:var(--text-muted); cursor:pointer; padding:6px; border-radius:6px }
+.pwd-toggle:focus{ outline:2px solid rgba(20,184,166,0.12) }
+
+/* errors and feedback */
+.field-error{ color:#ffb4c0; font-size:13px; min-height:18px; margin-bottom:6px }
+.feedback{ margin-top:12px; font-size:14px; min-height:20px }
+
+/* primary button */
+.btn.full{ width:100%; display:inline-block; text-align:center }
+.btn-primary.full{
+  background: linear-gradient(90deg, var(--teal-600), var(--teal-300));
+  color:#001;
+  padding:12px 14px;
+  font-weight:700;
+  border-radius:10px;
+  border:none;
+  box-shadow: 0 8px 18px rgba(13,148,136,0.12);
+}
+.btn-primary.full[disabled]{ opacity:.6; cursor:not-allowed; transform:none; box-shadow:none }
+
+/* links */
+.link-muted{ color:var(--text-muted); text-decoration:none }
+.link-accent{ color:var(--teal-300); text-decoration:none; font-weight:600 }
+.link-accent:hover{ color:var(--teal-500) }
+
+/* small text */
+.small{ font-size:13px }
+.center{text-align:center}
+.muted{ color:var(--text-muted) }
+
+/* responsive */
+@media (max-width:480px){
+  .auth-card{ padding:20px; border-radius:12px }
+  .auth-title{ font-size:22px }
+  .row-2{ flex-direction:column; }
+}


### PR DESCRIPTION
- Implemented signup page layout following the project's login pattern and Figma prototype.
- Fields: first name, last name, email, password, confirm password.
- Client-side validation: non-empty names, valid email, password min 6 chars, passwords must match.
- Password show/hide toggles for both password fields.
- Mock signup flow: on success shows feedback and redirects to login (mock behavior).
- Adjusted .auth-card max-width to 500px to match visual layout.

How to test:
1. Open src/pages/signup.html with Live Server.
2. Fill first name + last name, valid email and matching passwords (>=6 chars) → button enables, submit → shows success and redirects to login (mock).
3. Try invalid cases: empty names, invalid email, short password, mismatched passwords → inline errors appear; submit stays disabled.
4. Verify visual parity with login page (logo, spacing, colors) and responsiveness (desktop & mobile).

- [X] UI conforme protótipo (desktop & mobile)
- [X] Campos: Nome, Sobrenome, E-mail, Senha, Confirmar senha
- [X] Validação: nomes não vazios, email válido, senha mínimo 6 caracteres
- [X] Senhas devem coincidir
- [X] Show/hide password funcionando (ambos campos)
- [X] Mensagens de erro exibidas corretamente
- [X] Testado localmente com Live Server